### PR TITLE
Add triple dubs to prevent redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@
             We wanted to create a better experience for voters.
           </h3>
           <p>
-            In response to the significant number of visitors on <a href="https://usa.gov/" target="blank">USA.gov</a> that regularly query voter registration, we created a mechanism for registering to vote.
+            In response to the significant number of visitors on <a href="https://www.usa.gov/" target="blank">USA.gov</a> that regularly query voter registration, we created a mechanism for registering to vote.
           </p>
           <p>
             If you need more information on voting or the election process, visit <a href="https://www.usa.gov/voting" target="blank">USA.gov/voting</a>. To find this information in Spanish, visit <a href="https://gobierno.usa.gov/elecciones-electorales" target="blank">GobiernoUSA.gov</a>.


### PR DESCRIPTION
This patch removes the redirect that `https://usa.gov` causes.
