### PR TITLE
Update select to account for same selection

### DIFF
--- a/assets/js/stateSelect.js
+++ b/assets/js/stateSelect.js
@@ -1,3 +1,5 @@
+/* global $:false */
+
 var vote2016 = vote2016 || {};
 
 var isSafari = !!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/);
@@ -86,9 +88,23 @@ vote2016.website = {
   },
 
   bindStateSelect: function() {
+    var timer;
     $(".state-select select").bind("change", function(){
+      window.clearTimeout(timer);
+      vote2016.website.closeModal();
       vote2016.website.checkWebsite($(this));
       $("body").addClass("no-scroll");
+    });
+    $(".state-select select").on("click", function() {
+      var $select = $(this);
+      window.clearTimeout(timer);
+      timer = window.setTimeout(function () {
+        vote2016.website.checkWebsite($select);
+        $("body").addClass("no-scroll");
+      }, 2500);
+      if (null == $select.val()) {
+        window.clearTimeout(timer);
+      }
     });
   },
 


### PR DESCRIPTION
This patch adds a timer to account for someone opening the select menu
and wishing to see the modal again without changing it's value. This
fixes #22. The function to show the duplicate modal waits approximately
2.5 seconds rather arbitrarily. Because of this new functionality, the
change event now closes modals before opening new ones.

![select-dropdown-fix](https://cloud.githubusercontent.com/assets/706004/14148274/d1173e98-f66c-11e5-9cd5-c76efefe36ee.gif)

Could you take a look at this @stroupaloop. Thanks!
