### PR TITLE
Deprecate PIF repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Vote 2016
 
+**This repository has been deprecated. Please use the [`18F/vote-2016`] [18f-fork]
+fork to follow development for this project or to file any issues. You must open
+all pull requests against the `master` branch on the `18F/vote-2016` repository.**
+
+[18f-fork]: https://github.com/18F/vote-2016 "GitHub 18F Vote 2016 Fork"
+
 To get the SASS working, run the following command from the project directory:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Vote 2016
 
 **This repository has been deprecated. Please use the [`18F/vote-2016`] [18f-fork]
-fork to follow development for this project or to file any issues. You must open
-all pull requests against the `master` branch on the `18F/vote-2016` repository.**
+fork to follow development for this project or to file any issues. Please open
+[Pull Requests against the `master` branch] [18f-compare] on the `18F/vote-2016`
+repository.**
 
 [18f-fork]: https://github.com/18F/vote-2016 "GitHub 18F Vote 2016 Fork"
+[18f-compare]: https://github.com/18F/vote-2016/compare/master... "GitHub 18F Vote 2016 Pull Request"
 
 To get the SASS working, run the following command from the project directory:
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
-#Vote 2016
+# Vote 2016
 
-To get the SASS working, run `sass --watch assets/stylesheets/sass:assets/stylesheets/output` from the project directory.
+To get the SASS working, run the following command from the project directory:
+
+```sh
+sass --watch assets/stylesheets/sass:assets/stylesheets/output
+```
 
 ### Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):
 
-> This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
->
-> All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
+> This project is in the public domain within the United States, and copyright
+> and related rights in the work worldwide are waived through the
+> [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+> All contributions to this project will be released under the CC0 dedication.
+> By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ sass --watch assets/stylesheets/sass:assets/stylesheets/output
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):
 
-> This project is in the public domain within the United States, and copyright
-> and related rights in the work worldwide are waived through the
+> This project is in the public domain within the United States. Worldwide,
+> copyright and related rights are waived through the
 > [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 
 > All contributions to this project will be released under the CC0 dedication.


### PR DESCRIPTION
This patch adds the deprecation message to this repository and points
users to the `18F/vote-2016` repository. This will most likely be the last
commit on the `presidential-innovation-fellows/vote-2016` repository as
the 18F fork will contain all new work going forward.
